### PR TITLE
fix: use whole GH API response + repo definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ Use `method` input: `list`.
 The following inputs are required for this, and all subsequent, methods:
 
 * `github_token`: Token to authenticate with GitHub API.
-* `repo_owner`: Owner of the repository where artifacts are stored.
-* `repo_name`: Name of the repository where artifacts are stored.
+* `repo`: The target repository (in the format `owner/repo`).
 
 ```yml
     steps:
@@ -31,7 +30,7 @@ The following inputs are required for this, and all subsequent, methods:
           echo $json | jq -r '.[].name'
 ```
 
-Returns a JSON array of artifacts in the repository, based on value of `repo_owner` and `repo_name`.
+Returns standard API response of a JSON array of artifacts in the target repository (`repo`) - see [GitHub API documentation](https://docs.github.com/en/rest/actions/artifacts#list-artifacts-for-a-repository) for schema.
 
 ## Search for artifacts in a repository
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,10 @@ The following inputs are required for this, and all subsequent, methods:
 
       - name: List artifact names
         env:
-          json: ${{ steps.list-artifacts.outputs.artifacts }}
+          no_artifacts: ${{ fromJson(steps.list-artifacts.outputs.artifacts).total_count }}
+          artifacts_json: ${{ fromJson(steps.list-artifacts.outputs.artifacts).artifacts }}
         run: |
-          echo $json | jq -r '.[].name'
+          echo $json | jq -r '.artifacts.[].name'
 ```
 
 Returns standard API response of a JSON array of artifacts in the target repository (`repo`) - see [GitHub API documentation](https://docs.github.com/en/rest/actions/artifacts#list-artifacts-for-a-repository) for schema.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Returns a JSON array containing the response from the deletion API call of each 
   {
     "name": "target-artifact-0",
     "id": 123456789,
-    "delete_response": "HTTP/2.0 200 OK"
+    "delete_response": "HTTP/2.0 204 No Content"
   },
   {
     "name": "target-artifact-1",

--- a/README.md
+++ b/README.md
@@ -94,19 +94,19 @@ By default, a failed delete operation will not fail the action (but will show in
           fi
 ```
 
-Returns a JSON array containing the deletion result of each targeted artifact, e.g.:
+Returns a JSON array containing the response from the deletion API call of each targeted artifact, e.g.:
 
 ```json
 [
   {
     "name": "target-artifact-0",
     "id": 123456789,
-    "deleted": true
+    "delete_response": "HTTP/2.0 200 OK"
   },
   {
     "name": "target-artifact-1",
     "id": 234567890,
-    "deleted": false
+    "delete_response": "HTTP/2.0 404 Not Found"
   }
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -94,19 +94,19 @@ By default, a failed delete operation will not fail the action (but will show in
           fi
 ```
 
-Returns a JSON array containing the response from the deletion API call of each targeted artifact, e.g.:
+Returns a JSON array containing the deletion result of each targeted artifact, e.g.:
 
 ```json
 [
   {
     "name": "target-artifact-0",
     "id": 123456789,
-    "delete_response": "HTTP/2.0 204 No Content"
+    "deleted": true
   },
   {
     "name": "target-artifact-1",
     "id": 234567890,
-    "delete_response": "HTTP/2.0 404 Not Found"
+    "deleted": false
   }
 ]
 ```

--- a/action.yml
+++ b/action.yml
@@ -74,7 +74,7 @@ runs:
 
     - name: Search artifacts
       id: search
-      if: contains(fromJson('["search", "delete"]'), inputs.method) && fromJson(steps.list.outputs.response).total_count > 0 && inputs.artifact_name != ''
+      if: contains(fromJson('["search", "delete"]'), inputs.method) && inputs.artifact_name != ''
       shell: bash
       env:
         artifacts: ${{ steps.list.outputs.response }}
@@ -87,7 +87,7 @@ runs:
         # Validate and report result
         search_count=$(echo $search | jq -r 'length')
         if [[ "$search_count" -gt 0 ]]; then
-          echo "Found $(echo search | jq 'length') artifacts(s) matching the search criteria! (Search regex: $search_query)"
+          echo "Found $search_count artifacts(s) matching the search criteria! (Search regex: $search_query)"
         else
           echo "No artifacts found! (Search regex: $search_query)"
           if [[ "$no_results_fail" == "true" ]]; then

--- a/action.yml
+++ b/action.yml
@@ -104,7 +104,7 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github_token }}
-        repo: ${{ inputs.repo_owner }}/${{ inputs.repo_name }}
+        repo: ${{ inputs.repo }}
         artifacts: ${{ steps.search.outputs.results }}
         no_delete_fail: ${{ inputs.action_fail_on_delete_error }}
       run: |

--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github_token }}
-        repo: ${{ inputs.repo_owner }}/${{ inputs.repo_name }}
+        repo: ${{ inputs.repo }}
       run: |
         # Get response + HTTP code
         gh api -i -X GET \

--- a/action.yml
+++ b/action.yml
@@ -77,12 +77,12 @@ runs:
       if: contains(fromJson('["search", "delete"]'), inputs.method) && fromJson(steps.list.outputs.response).total_count > 0 && inputs.artifact_name != ''
       shell: bash
       env:
-        artifacts: ${{ fromJson(steps.list.outputs.response).artifacts }}
+        artifacts: ${{ steps.list.outputs.response }}
         search_query: ${{ inputs.search_name }}
         no_results_fail: ${{ inputs.action_fail_on_empty_search }}
       run: |
         # Extract target artifact(s)
-        search=$(echo $artifacts | jq -c --arg q "$search_query" 'map(select(.name | test($q)))')
+        search=$(echo $artifacts | jq -c --arg q "$search_query" '.artifacts | map(select(.name | test($q)))')
 
         # Validate and report result
         search_count=$(echo $search | jq -r 'length')

--- a/action.yml
+++ b/action.yml
@@ -106,12 +106,12 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.github_token }}
         repo: ${{ inputs.repo }}
-        artifacts: ${{ steps.search.outputs.results }}
+        search: ${{ steps.search.outputs.results }}
         no_delete_fail: ${{ inputs.action_fail_on_delete_error }}
       run: |
         # Delete artifacts
         results="[]"
-        for artifact in $(echo $artifacts | jq -r '.[]'); do
+        for artifact in $(echo $search | jq -rc '.[]'); do
           id=$(echo $artifact | jq -r '.id')
           name=$(echo $artifact | jq -r '.name')
           echo "Deleting artifact: $name (ID: $id)..."

--- a/action.yml
+++ b/action.yml
@@ -122,10 +122,14 @@ runs:
           readarray -t response <<< $(cat $id.txt)
 
           # Validate HTTP code
-          if [[ ! "${response[0]}" =~ ("200 OK"|"204 No Content"$) ]]; then
+          if [[ "${response[0]}" =~ ("200 OK"|"204 No Content"$) ]]; then
+            # Artifact deleted successfully
+            result=true
+          else
             echo "  Error calling GitHub API!"
             echo "  Response:"
             cat $id.txt
+            result=false
             if [[ "$no_delete_fail" == "true" ]]; then
               exit 1
             fi
@@ -133,21 +137,19 @@ runs:
 
           # Add result to output array
           results=$(echo $results | jq -c \
-            --arg id       "$id" \
-            --arg name     "$name" \
-            --arg response "${response[0]}" \
+            --arg     id     "$id" \
+            --arg     name   "$name" \
+            --argjson result "$result" \
             '. + [{
-              "name":            $name,
-              "id":              $id,
-              "delete_response": $response
+              "name":    $name,
+              "id":      $id,
+              "deleted": $result
             }]'
           )
 
           # Cleanup
           rm $id.txt
-          unset id
-          unset name
-          unset response
+          unset id name response result
           echo "... done."
         done
 

--- a/action.yml
+++ b/action.yml
@@ -142,7 +142,7 @@ runs:
             '. + [{
               "name":            $name,
               "id":              $id,
-              "delete_response": $result
+              "delete_response": $response
             }]'
           )
 

--- a/action.yml
+++ b/action.yml
@@ -124,12 +124,9 @@ runs:
           readarray -t response <<< $(cat $id.txt)
 
           # Validate HTTP code
-          if [[ "${response[0]}" =~ ["200 OK$"] ]]; then
-            echo "GitHub API called successfully!"
-            results=true
-          else
-            echo "Error calling GitHub API!"
-            echo "Response:"
+          if [[ ! "${response[0]}" =~ ["200 OK$"] ]]; then
+            echo "  Error calling GitHub API!"
+            echo "  Response:"
             cat $id.txt
             result=false
             if [[ "$no_delete_fail" == "true" ]]; then
@@ -139,20 +136,20 @@ runs:
 
           # Add result to output array
           results=$(echo $results | jq -c \
-            --arg     id     "$id" \
-            --arg     name   "$name" \
-            --argjson result "$result" \
+            --arg id       "$id" \
+            --arg name     "$name" \
+            --arg response "${response[0]}" \
             '. + [{
-              "name":    $name,
-              "id":      $id,
-              "deleted": $result
+              "name":            $name,
+              "id":              $id,
+              "delete_response": $result
             }]'
           )
 
           # Cleanup
           rm $id.txt
           unset response
-          echo "  ... done."
+          echo "... done."
         done
 
         # Set output

--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,7 @@ runs:
         GH_TOKEN: ${{ inputs.github_token }}
         repo: ${{ inputs.repo }}
       run: |
+        # List all artifacts in repo
         # Get response + HTTP code
         gh api -i -X GET \
           -H "Accept: application/vnd.github+json" \
@@ -74,7 +75,7 @@ runs:
 
     - name: Search artifacts
       id: search
-      if: contains(fromJson('["search", "delete"]'), inputs.method) && inputs.artifact_name != ''
+      if: contains(fromJson('["search", "delete"]'), inputs.method) && inputs.search_name != ''
       shell: bash
       env:
         artifacts: ${{ steps.list.outputs.response }}

--- a/action.yml
+++ b/action.yml
@@ -54,9 +54,7 @@ runs:
         readarray -t response <<< $(cat response.txt)
 
         # Validate HTTP code
-        if [[ "${response[0]}" =~ ["200 OK$"] ]]; then
-          echo "GitHub API called successfully!"
-        else
+        if [[ ! "${response[0]}" =~ ("200 OK"$) ]]; then
           echo "Error calling GitHub API!"
           echo "Response:"
           cat response.txt
@@ -124,11 +122,10 @@ runs:
           readarray -t response <<< $(cat $id.txt)
 
           # Validate HTTP code
-          if [[ ! "${response[0]}" =~ ["200 OK$"] ]]; then
+          if [[ ! "${response[0]}" =~ ("200 OK"|"204 No Content"$) ]]; then
             echo "  Error calling GitHub API!"
             echo "  Response:"
             cat $id.txt
-            result=false
             if [[ "$no_delete_fail" == "true" ]]; then
               exit 1
             fi
@@ -148,6 +145,8 @@ runs:
 
           # Cleanup
           rm $id.txt
+          unset id
+          unset name
           unset response
           echo "... done."
         done

--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,7 @@ runs:
         # Get response + HTTP code
         gh api -i -X GET \
           -H "Accept: application/vnd.github+json" \
-          .artifacts /repos/$repo/actions/artifacts \
+          /repos/$repo/actions/artifacts \
           > response.txt
         readarray -t response <<< $(cat response.txt)
 
@@ -66,7 +66,7 @@ runs:
         echo "response=$(echo "${response[-1]}" | jq -c)" >> $GITHUB_OUTPUT
 
         # Report results
-        echo "Found $(echo "${response[-1]}" | jq -r 'length') artifact(s)!"
+        echo "Found $(echo "${response[-1]}" | jq -r '.total_count') artifact(s)!"
 
         # Cleanup
         rm response.txt
@@ -74,10 +74,10 @@ runs:
 
     - name: Search artifacts
       id: search
-      if: contains(fromJson('["search", "delete"]'), inputs.method) && steps.list.outputs.response != '[]' && inputs.artifact_name != ''
+      if: contains(fromJson('["search", "delete"]'), inputs.method) && fromJson(steps.list.outputs.response).total_count > 0 && inputs.artifact_name != ''
       shell: bash
       env:
-        artifacts: ${{ steps.list.outputs.response }}
+        artifacts: ${{ fromJson(steps.list.outputs.response).artifacts }}
         search_query: ${{ inputs.search_name }}
         no_results_fail: ${{ inputs.action_fail_on_empty_search }}
       run: |


### PR DESCRIPTION
## Context

Omission of the `-q` option in the GitHub API request threw into question the need to truncate the output at all.

I have chosen to keep and provide the entire response from GitHub API, and just select the bits needed moving forward.

## Needs

1. GitHub API call broken (lack of `-q`).
2. Repo definitions had not been updated.

## Solutions

1. Remove argument to `-q` to provide and use the `total_count` value, fixing the call.
2. Used `${{ inputs.repo }}` for `repo` env var.

## Evidence

### Visual Evidence

No artifacts found:

<img width="482" alt="image" src="https://github.com/user-attachments/assets/a3a107c6-ac24-430b-bcc2-da88d38c41c0" />

Artifacts deleted:

<img width="683" alt="image" src="https://github.com/user-attachments/assets/82b34b46-ac11-4815-ae41-254122feac45" />
