### PR TITLE
Fix long arg list

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ It populates the following outputs:
           echo $artifacts | jq 'map(.name)'
 ```
 
+The list artifacts is available in the `artifacts_list.json` file.
+
 ## Search for artifacts in a repository
 
 Use `method` input: `search`.
@@ -81,6 +83,8 @@ It populates the following outputs (in addition to `list` outputs):
             echo $entry | jq '{"name", "id", "size_in_bytes", "updated_at", "archive_download_url"}'
           done
 ```
+
+The list of search results is available in the `artifacts_search.json` file.
 
 ## Delete target artifacts in a repository
 
@@ -127,3 +131,9 @@ Populates the following outputs (in addition to `search` outputs):
             fi
           done
 ```
+
+The list of artifact statuses is available in the `artifacts_delete.json` file.
+
+## Additional Inputs
+
+* `cleanup_files`: Remove files after run.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 List, search or delete GitHub artifacts.
 
+Results are available either via `output` or in files.
+
 # Usage
 
 ## List artifacts in a repository
@@ -43,7 +45,7 @@ It populates the following outputs:
           echo $artifacts | jq 'map(.name)'
 ```
 
-The list artifacts is available in the `artifacts_list.json` file.
+The list of artifacts is available in the `artifacts_list.json` file.
 
 ## Search for artifacts in a repository
 

--- a/action.yml
+++ b/action.yml
@@ -112,14 +112,14 @@ runs:
           page_list=$(echo "${response[-1]}" | jq '.artifacts')
 
           # Add to full list file
-          echo "$(cat artifacts.json | jq -rc --argjson list "$page_list" '. += $list | flatten')" > artifacts_list.json
+          echo "$(cat artifacts_list.json | jq -rc --argjson list "$page_list" '. += $list | flatten')" > artifacts_list.json
 
           unset response
         done
         echo "... done!"
 
         # Verify the number of fetched artifacts matches what GitHub says
-        list_size=$(cat artifacts.json | jq 'length')
+        list_size=$(cat artifacts_list.json | jq 'length')
         if [[ "$list_size" -eq "$no_artifacts" ]]; then
           echo "Fetched all artifacts!"
         else

--- a/action.yml
+++ b/action.yml
@@ -93,6 +93,8 @@ runs:
         page_size: 100
         mismatch_fail: ${{ inputs.action_fail_on_list_mismatch }}
       run: |
+        # Fetch all artifacts in repo
+
         # Set placeholder file
         echo '[]' > artifacts_list.json
 

--- a/action.yml
+++ b/action.yml
@@ -94,7 +94,7 @@ runs:
         mismatch_fail: ${{ inputs.action_fail_on_list_mismatch }}
       run: |
         # Set placeholder file
-        echo '[]' > artifacts.json
+        echo '[]' > artifacts_list.json
 
         # Calculate how many pages we need to iterate through
         pages=$(expr 1 + $(expr $no_artifacts / $page_size))
@@ -112,7 +112,7 @@ runs:
           page_list=$(echo "${response[-1]}" | jq '.artifacts')
 
           # Add to full list file
-          echo "$(cat artifacts.json | jq -rc --argjson list "$page_list" '. += $list | flatten')" > artifacts.json
+          echo "$(cat artifacts.json | jq -rc --argjson list "$page_list" '. += $list | flatten')" > artifacts_list.json
 
           unset response
         done
@@ -131,10 +131,7 @@ runs:
         fi
 
         # Set output
-        echo "artifacts=$(cat artifacts.json | jq -rc)" >> $GITHUB_OUTPUT
-
-        # Cleanup
-        rm artifacts.json
+        echo "artifacts=$(cat artifacts_list.json | jq -rc)" >> $GITHUB_OUTPUT
 
     - name: Search artifacts
       id: search
@@ -144,12 +141,11 @@ runs:
         search_query: ${{ inputs.search_name }}
         no_results_fail: ${{ inputs.action_fail_on_empty_search }}
       run: |
-        # Extract target artifact(s)
-        # Populate var in-script to avoid "Argument list too long" errors
-        search=$(echo "${{ steps.list.outputs.artifacts }}" | jq -c --arg q "$search_query" '.artifacts | map(select(.name | test($q)))')
+        # Extract target artifact(s) to results file
+        echo "$(cat artifacts_list.json | jq -rc --arg q "$search_query" '.artifacts | map(select(.name | test($q)))')" > artifacts_search.json
 
         # Validate and report result
-        search_count=$(echo "$search" | jq -r 'length')
+        search_count=$(cat artifacts_search.json | jq -r 'length')
         if [[ "$search_count" -gt 0 ]]; then
           echo "Found $search_count artifacts(s) matching the search criteria! (Search regex: $search_query)"
         else
@@ -160,7 +156,7 @@ runs:
         fi
 
         # Set output
-        echo "results=$(echo $search | jq -c)" >> $GITHUB_OUTPUT
+        echo "results=$(cat artifacts_search.json | jq -rc)" >> $GITHUB_OUTPUT
 
     - name: Delete artifacts
       id: delete
@@ -169,12 +165,11 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.github_token }}
         repo: ${{ inputs.repo }}
-        search: ${{ steps.search.outputs.results }}
         no_delete_fail: ${{ inputs.action_fail_on_delete_error }}
       run: |
         # Delete artifacts
         results="[]"
-        for artifact in $(echo "$search" | jq -rc '.[]'); do
+        for artifact in $(cat artifacts_search.json | jq -rc '.[]'); do
           id=$(echo "$artifact" | jq -r '.id')
           name=$(echo "$artifact" | jq -r '.name')
           echo "Deleting artifact: $name (ID: $id)..."
@@ -220,8 +215,15 @@ runs:
 
         # Set output
         echo "results=$(echo $results | jq -c)" >> $GITHUB_OUTPUT
+        echo "$results" > artifacts_delete.json
 
         # Report results
         total=$(echo "$results" | jq -r 'length')
         success=$(echo "$results" | jq -r 'map(select(.deleted == true)) | length')
         echo "Successfully deleted $success/$total artifacts!"
+
+    - name: Cleanup files
+      if: inputs.cleanup_files == 'true'
+      shell: bash
+      run: |
+        rm artifacts_list.json artifacts_search.json artifacts_delete.json

--- a/action.yml
+++ b/action.yml
@@ -225,7 +225,7 @@ runs:
         echo "Successfully deleted $success/$total artifacts!"
 
     - name: Cleanup files
-      if: inputs.cleanup_files == 'true'
+      if: always() && inputs.cleanup_files == 'true'
       shell: bash
       run: |
         rm artifacts_list.json artifacts_search.json artifacts_delete.json

--- a/action.yml
+++ b/action.yml
@@ -111,7 +111,7 @@ runs:
             "/repos/${repo}/actions/artifacts?per_page=${page_size}&page=${page}")
 
           # Extract artifacts array from response
-          page_list=$(echo "${response[-1]}" | jq '.artifacts')
+          page_list=$(echo "${response[-1]}" | jq -rc '.artifacts')
 
           # Add to full list file
           echo "$(cat artifacts_list.json | jq -rc --argjson list "$page_list" '. += $list | flatten')" > artifacts_list.json
@@ -228,4 +228,4 @@ runs:
       if: always() && inputs.cleanup_files == 'true'
       shell: bash
       run: |
-        rm artifacts_list.json artifacts_search.json artifacts_delete.json
+        rm -f artifacts_list.json artifacts_search.json artifacts_delete.json

--- a/action.yml
+++ b/action.yml
@@ -141,12 +141,12 @@ runs:
       if: contains(fromJson('["search", "delete"]'), inputs.method) && inputs.search_name != ''
       shell: bash
       env:
-        artifacts: ${{ steps.list.outputs.artifacts }}
         search_query: ${{ inputs.search_name }}
         no_results_fail: ${{ inputs.action_fail_on_empty_search }}
       run: |
         # Extract target artifact(s)
-        search=$(echo "$artifacts" | jq -c --arg q "$search_query" '.artifacts | map(select(.name | test($q)))')
+        # Populate var in-script to avoid "Argument list too long" errors
+        search=$(echo "${{ steps.list.outputs.artifacts }}" | jq -c --arg q "$search_query" '.artifacts | map(select(.name | test($q)))')
 
         # Validate and report result
         search_count=$(echo "$search" | jq -r 'length')

--- a/action.yml
+++ b/action.yml
@@ -142,7 +142,7 @@ runs:
         no_results_fail: ${{ inputs.action_fail_on_empty_search }}
       run: |
         # Extract target artifact(s) to results file
-        echo "$(cat artifacts_list.json | jq -rc --arg q "$search_query" '.artifacts | map(select(.name | test($q)))')" > artifacts_search.json
+        echo "$(cat artifacts_list.json | jq -rc --arg q "$search_query" 'map(select(.name | test($q)))')" > artifacts_search.json
 
         # Validate and report result
         search_count=$(cat artifacts_search.json | jq -r 'length')


### PR DESCRIPTION
## Needs

1. Large lists produce `Argument list too long` error when passed to other steps via `outputs`

## Solutions

1. Use files to pass data between steps. Persist files afterwards for easy data recollection (provide option to remove).

## Evidence

<img width="897" height="1408" alt="image" src="https://github.com/user-attachments/assets/c98f3406-9e66-420a-aa42-9b80c22d322c" />
